### PR TITLE
Minor wording changes for SPARK on the home page

### DIFF
--- a/src/components/HomepageFeatures/features.json
+++ b/src/components/HomepageFeatures/features.json
@@ -43,23 +43,23 @@
     "description": "Gradually adopt the SPARK subset to reach various levels of assurance. Higher levels take more effort, but give more benefits and stronger guarantees.",
     "items": [
       {
-        "title": "Valid SPARK",
-        "description": "Restrict Ada packages to the SPARK subset. Avoids side-effects in functions and parameter aliasing.",
+        "title": "Validates code",
+        "description": "Restricts Ada packages to the SPARK subset. Avoids side-effects in functions and parameter aliasing.",
         "icon": "spark-stone"
       },
       {
-        "title": "Initialization and correct data flow",
+        "title": "Checks initialization and data flow",
         "description": "No uninitialized variables are read or undesired access to globals occurs.",
         "icon": "spark-bronze"
       },
       {
-        "title": "Absence of run-time errors",
+        "title": "Proves the absence of run-time errors",
         "description": "No buffer and arithmetic overflow, division by zero, or values out of range, among others, can occur.",
         "icon": "spark-silver"
       },
       {
-        "title": "Key integrity properties",
-        "description": "Verify integrity of data and valid state transitions.",
+        "title": "Ensures key integrity properties",
+        "description": "Verifies integrity of data and valid state transitions.",
         "icon": "spark-gold"
       }
     ]


### PR DESCRIPTION
We are printing a SPARK banner for FOSDEM 23 and we took content from the ada-lang.io home page with a slightly different wording. So I am submitting it here in case you want to use this version.