### PR TITLE
Fix quoting in commands for Emacs

### DIFF
--- a/docs/learn/getting-started/editors.md
+++ b/docs/learn/getting-started/editors.md
@@ -96,13 +96,13 @@ Set Alire to use Emacs when invoking `alr edit`.
   <TabItem value="linux" label="Linux">
 
 ```bash
-alr config --set --global editor.cmd 'emacs --eval=(ada-build-prompt-select-prj-file"${GPR_FILE}) ${GPR_FILE}'
+alr config --set --global editor.cmd 'emacs --eval=(ada-build-prompt-select-prj-file"${GPR_FILE}") ${GPR_FILE}'
 ```
   </TabItem>
   <TabItem value="mac" label="macOS">
 
 ```bash
-alr config --set editor.cmd "open -n -a emacs ${GPR_FILE}"
+alr config --set editor.cmd 'open -n -a emacs ${GPR_FILE}'
 ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
The Linux command was broken since 36c5ff1

The macOS command requires also single quotes to avoid GPR_FILE being interpreted.  Confirmed this is how Simon Wright is in fact executing it:

https://lists.nongnu.org/archive/html/ada-mode-users/2023-10/msg00001.html