### PR TITLE
Remove draft status from macOS pages.

### DIFF
--- a/docs/learn/getting-started/macos-issues/alire-vs-aarch64.md
+++ b/docs/learn/getting-started/macos-issues/alire-vs-aarch64.md
@@ -1,6 +1,5 @@
 ---
 sidebar_position: 3
-draft: true
 ---
 
 # Alire vs Apple silicon

--- a/docs/learn/getting-started/macos-issues/alire.md
+++ b/docs/learn/getting-started/macos-issues/alire.md
@@ -1,6 +1,5 @@
 ---
 sidebar_position: 2
-draft: true
 ---
 
 # Alire

--- a/docs/learn/getting-started/macos-issues/crates.md
+++ b/docs/learn/getting-started/macos-issues/crates.md
@@ -1,6 +1,5 @@
 ---
 sidebar_position: 4
-draft: true
 ---
 
 # Crates for macOS

--- a/docs/learn/getting-started/macos-issues/hardware.md
+++ b/docs/learn/getting-started/macos-issues/hardware.md
@@ -1,6 +1,5 @@
 ---
 sidebar_position: 1
-draft: true
 ---
 
 # Hardware

--- a/docs/learn/getting-started/macos-issues/issues.md
+++ b/docs/learn/getting-started/macos-issues/issues.md
@@ -1,6 +1,5 @@
 ---
 sidebar_position: 100
-draft: true
 ---
 
 # Issues


### PR DESCRIPTION
 The last PR didn’t actually appear on the web: I guess it’s the draft=true setting! which I copied from one of the other pages (the ones with TODO, hence draft, of course). Removed.

I have more to do, but this is a start.