### PR TITLE
Add link to Ada-Europe

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -232,6 +232,10 @@ const config = {
                 href: "https://arg.adaic.org/home"
               },
               {
+                label: "Ada Europe",
+                href: "https://ada-europe.org/"
+              },
+              {
                 label: "GitHub",
                 href: `https://github.com/${gitHubUserName}/${gitHubProjectName}`,
                 className: "fa-icon footer__image footer-github-link"


### PR DESCRIPTION
I think a link to Ada-Europe would be nice to have. They are a pretty active community and have publications and conference that revolve around Ada. They also bring together the different Ada-* groups in Europe such as France, Belgium and Spain.