### PR TITLE
Add link to Docusaurus website in the copyright notice

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -245,7 +245,7 @@ const config = {
           width: 128,
           height: 128
         },
-        copyright: `Copyright © ${new Date().getFullYear()} and licensed under Apache 2.0 unless otherwise noted, by the ${gitHubProjectName} developers. Built with Docusaurus.`
+        copyright: `Copyright © ${new Date().getFullYear()} and licensed under Apache 2.0 unless otherwise noted, by the ${gitHubProjectName} developers. Built with <a href="https://docusaurus.io/">Docusaurus</a>.`
       },
       prism: {
         theme: lightCodeTheme,


### PR DESCRIPTION
Another minor addition/fix(?).


I know that small PRs are a bit stupid. I am doing this just as an exercise for myself and in order to get used to the project/TypeScript/React/Docusaurus and in the meantime, I "fix" what I find. But you can always tell me to just create a bigger PR :)