### PR TITLE
Updated macOS crates info.

### DIFF
--- a/docs/learn/getting-started/macos-issues/alire-vs-aarch64.md
+++ b/docs/learn/getting-started/macos-issues/alire-vs-aarch64.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 030
 ---
 
 # Alire vs Apple silicon

--- a/docs/learn/getting-started/macos-issues/alire.md
+++ b/docs/learn/getting-started/macos-issues/alire.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 020
 ---
 
 # Alire

--- a/docs/learn/getting-started/macos-issues/crates.md
+++ b/docs/learn/getting-started/macos-issues/crates.md
@@ -1,27 +1,43 @@
 ---
-sidebar_position: 4
+sidebar_position: 040
 ---
 
 # Crates for macOS
 
-There's a Mac-special index which holds crate versions that
+There's a Mac-special [Alire repository on Github](https://github.com/simonjwright/alire-index.mac.git) which provides three things, two of which are tool-related and hopefully temporary.
 
-- support Apple silicon,
-- overcome some issues that arise from macOS features:
-  - _gprbuild_ can try to build static standalone libraries, where the 'standalone' part means that the library will be automatically elaborated. It does this using features available in GNU binutils, but not in Mach-O binary. Alternative versions of crates that normally would attempt this are provided (`libadalang`, `langkit_support`).
+- [Alire](#alire) itself
+- [Workrounds](#workrounds) for macOS-related issues
+- [Toolchain items](#toolchain) (compiler, gprbuild)
 
-The crates provided are:
+## <a name="alire">Alire</a>
 
-- Tools
-  - `gnat_macos_aarch64=13.1.1`, native GNAT for Apple silicon.
-  - `gprbuild=23.0.1-mac-aarch64`, matching gprbuild (avoids you having to say `--target=aarch64-apple-darwin` at every compilation!)
-- Libraries
-  - `langkit_support-23.0.1`, builds a plain static library.
-  - `libadalang-23.0.1`, likewise.
+At 2024-04-19, the official Alire site only supports an Intel (x86_64) build of Alire, which won't support native development on Apple silicon.
+
+You can find an Apple (aarch64) build of Alire 2.0.1 [here](https://github.com/simonjwright/alire-index.mac/releases/tag/alr-2.0.1-bin-aarch64-macos).
+
+## <a name="workrounds">Workrounds</a>
+
+_gprbuild_ can try to build static standalone libraries, where the 'standalone' part means that the library will be automatically elaborated. It does this using features available in GNU binutils, but not in Mach-O binary -- on either machine architecture. Alternative versions of crates that normally would attempt this are provided in the [Mac-related index](#index):
+
+- `langkit_support-24.0.1`, builds a plain static library.
+- `libadalang-24.0.1`, likewise.
+
+## <a name="toolchain">Toolchain items</a>
+
+The crates in the [Mac-related index](#index) are
+
+- `gnat_macos_aarch64=13.2.2`, native GNAT for Apple silicon.
+- `gprbuild=24.0.1-mac-aarch64`, matching gprbuild (avoids you having to say `--target=aarch64-apple-darwin` at every compilation!)
+
+Note that Alire's community index already (2024-04-19) provides `gnat_native=13.2.2` for macOS; no doubt an equivalent _gprbuild_ will be available shortly.
+
+## <a name="index">Installing the Mac-special Alire index</a>
 
 To install:
 
-```
+```sh
+$ alr index --reset-community
 $ alr index \
    --add=git+https://github.com/simonjwright/alire-index.mac.git \
    --before=community \

--- a/docs/learn/getting-started/macos-issues/hardware.md
+++ b/docs/learn/getting-started/macos-issues/hardware.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 010
 ---
 
 # Hardware


### PR DESCRIPTION
The "crates" subsection referred to outdated software versions, and needed to be better organised.

Also, it's a pity that subsection ordering within a section is addressed within the subsection; to minimise the potential impact of introducing additional subsections, I've spread the `sidebar_position`s out.