### PR TITLE
Update ALR release to 2.0.2. MacOS rework.

### DIFF
--- a/docs/learn/getting-started/installation.md
+++ b/docs/learn/getting-started/installation.md
@@ -10,12 +10,12 @@ By far the easiest way to get hold of an Ada toolchain is to use the Ada package
 
 ## Alire
 
-The Alire website's [Releases page](https://github.com/alire-project/alire/releases) provides Intel builds:
+The Alire website's [Releases page](https://github.com/alire-project/alire/releases) provides builds:
 
-- the current stable build, [v2.0.0](https://github.com/alire-project/alire/releases/tag/v2.0.0),
+- the current stable build, [v2.0.2](https://github.com/alire-project/alire/releases/tag/v2.0.2),
 - a [nightly build](https://github.com/alire-project/alire/releases/tag/nightly).
 
-Any of these can be installed as described [here](https://alire.ada.dev/docs/#alr-on-macos); follow up with these [first steps](https://alire.ada.dev/docs/#first-steps) (this will have the added effect of installing a toolchain for you!)
+Any of these can be installed as described [here](https://alire.ada.dev/docs/#installation); follow up with these [first steps](https://alire.ada.dev/docs/#first-steps) (this will have the added effect of installing a toolchain for you!)
 
 ## Toolchain
 

--- a/docs/learn/getting-started/macos-issues/alire-vs-aarch64.md
+++ b/docs/learn/getting-started/macos-issues/alire-vs-aarch64.md
@@ -4,7 +4,9 @@ sidebar_position: 030
 
 # Alire vs Apple silicon
 
-Alire releases available from the [Alire website](https://github.com/alire-project/alire/releases) are all built for Intel silicon. For pure Ada work, this has no effect, whether or not you're working on Apple silicon.
+Alire releases available from the [Alire website](https://github.com/alire-project/alire/releases) are available for either Intel or Apple silicon, but at the time of writing the download links on the landing page refer only to the Intel version.
+
+For pure Ada work, this has no effect, whether or not you're working on Apple silicon.
 
 One area where there's a considerable impact is when your work involves "[external releases](https://alire.ada.dev/docs/#external-releases)". These are external libraries which Alire manages as required using your system's "package manager". An example is the crate `sdlada`, which depends on `libsdl2` amongst others. On a Debian system, Alire will load the package `libsdl2-dev`; on macOS with Homebrew, `sdl2`.
 

--- a/docs/learn/getting-started/macos-issues/alire.md
+++ b/docs/learn/getting-started/macos-issues/alire.md
@@ -10,9 +10,9 @@ By far the easiest way to get hold of a Mac toolchain is to use the Ada package 
 
 Before doing that, there is a preparatory step required for any development on a Mac.
 
-You **must** have either _Xcode_ or the Command Line Tools installed (the CLTs are a lot smaller). **If you have version 15.0 installed, you need to update to at least version 15.1**.
+You **must** have either Xcode or the Command Line Tools installed (the CLTs are a lot smaller). **If you have version 15.0 installed, you need to update to at least version 15.1**.
 
-_Xcode_ can be downloaded from the App Store.
+Xcode can be downloaded from the App Store.  
 Install the Command Line Tools by `sudo xcode-select --install`.
 
 If you suspect your copy of the Command Line Tools is old, you can delete it by
@@ -31,9 +31,9 @@ softwareupdate --history | grep Command
 
 ## Installing `alr`
 
-The Alire website's [Releases page](https://github.com/alire-project/alire/releases) provides Intel builds:
+The Alire website's [Releases page](https://github.com/alire-project/alire/releases) provides builds for both Intel (`x86_64`) and Apple (`aarch64`) silicon
 
-- the current stable build, [v2.0.1](https://github.com/alire-project/alire/releases/tag/v2.0.1)
+- the current stable build, [v2.0.2](https://github.com/alire-project/alire/releases/tag/v2.0.2)
 - a [nightly build](https://github.com/alire-project/alire/releases/tag/nightly).
 
 Any of these can be installed as described [here](https://alire.ada.dev/docs/#alr-on-macos).

--- a/docs/learn/getting-started/macos-issues/crates.md
+++ b/docs/learn/getting-started/macos-issues/crates.md
@@ -4,37 +4,16 @@ sidebar_position: 040
 
 # Crates for macOS
 
-There's a Mac-special [Alire repository on Github](https://github.com/simonjwright/alire-index.mac.git) which provides three things, two of which are tool-related and hopefully temporary.
+There's a Mac-special [Alire repository on Github](https://github.com/simonjwright/alire-index.mac.git) which provides for macOS-related issues.
 
-- [Alire](#alire) itself
-- [Workarounds](#workarounds) for macOS-related issues
-- [Toolchain items](#toolchain-items) (compiler, gprbuild)
-
-## <a name="alire">Alire</a>
-
-At 2024-07-31, the official Alire site only supports an Intel (x86_64) build of Alire, which won't support native development on Apple silicon (there is an aarch64 version in the [nightly](https://github.com/alire-project/alire/releases/tag/nightly) builds).
-
-You can find an Apple (aarch64) build of Alire 2.0.1 [here](https://github.com/simonjwright/alire-index.mac/releases/tag/alr-2.0.1-bin-aarch64-macos).
-
-## <a name="workarounds">Workarounds</a>
+## Workarounds
 
 _gprbuild_ can try to build static standalone libraries, where the 'standalone' part means that the library will be automatically elaborated. It does this using features available in GNU binutils, but not in Mach-O binary -- on either machine architecture. Alternative versions of crates that normally would attempt this are provided in the [Mac-related index](#installing-the-mac-special-alire-index):
 
 - `langkit_support-24.0.1`, builds a plain static library.
 - `libadalang-24.0.1`, likewise.
 
-## <a name="toolchain-items">Toolchain items</a>
-
-The toolchain crates in the [Mac-related index](#installing-the-mac-special-alire-index) are
-
-- `gnat_macos_aarch64=14.1.0-1`, native GNAT for Apple silicon.
-- `gprbuild=24.0.1-mac-aarch64`, matching gprbuild (avoids you having to say `--target=aarch64-apple-darwin` at every compilation!)
-
-However, you should not need to use them, because Alire's community index already (2024-07-31) provides `gnat_native=14.1.3` and `gprbuild=24.0.1` for macOS, in both x86_64 and aarch64 versions; if you have the appropriate version of `alr` it will select the appropriate versions of the tools.
-
-Note that the 14.1.3 compiler should more properly be identified as 14.1.0-3, since the base compiler is still FSF GCC 14.1.0, and this is the third released build.
-
-## <a name="installing-the-mac-special-alire-index">Installing the Mac-special Alire index</a>
+## Installing the Mac-special Alire index
 
 To install:
 

--- a/docs/learn/getting-started/macos-issues/issues.md
+++ b/docs/learn/getting-started/macos-issues/issues.md
@@ -4,10 +4,33 @@ sidebar_position: 100
 
 # Issues
 
-- [Linking error](#linking-error)
-- [Unhandled exceptions](#unhandled-exceptions)
-- [Transparent solution](#transparent-solution)
-- [The future](#the-future)
+- Issues
+  - [C compilation failure](#c-compilation-failure)
+  - [Linking error](#linking-error) (`ld: Assertion failed`)
+  - [Unhandled exceptions](#unhandled-exceptions)
+
+## <a name="c-compilation-failure">C compilation failure</a>
+
+If you get apparently self-contradictory C- or C++-related errors like
+
+```sh
+$ gcc -c hello.c
+In file included from hello.c:1:
+/opt/gcc-14.2.0-1-aarch64/lib/gcc/aarch64-apple-darwin21/14.2.0/include-fixed/stdio.h:83:8:
+ error: unknown type name ‘FILE’
+   83 | extern FILE *__stdinp;
+      |        ^~~~
+/opt/gcc-14.2.0-1-aarch64/lib/gcc/aarch64-apple-darwin21/14.2.0/include-fixed/stdio.h:81:1:
+ note: ‘FILE’ is defined in header ‘<stdio.h>’; this is probably
+ fixable by adding ‘#include <stdio.h>’
+   80 | #include <sys/_types/_seek_set.h>
+  +++ |+#include <stdio.h>
+   81 |
+```
+
+it's because your Software Development Kit (SDK: Xcode or the Command Line Tools) has been upgraded to version 16, and your installed compiler hasn't been built to handle it; see [GCC PR 116980](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116980).
+
+Until that's resolved, the only general solution is to revert to SDK15.
 
 ## <a name="linking-error">Linking error</a>
 
@@ -25,20 +48,16 @@ This happened because Apple had introduced a new linker (`ld`). A workround for 
 
 (notice the change from dash to underscore!) This fix doesn't work with older SDKs that don't have `ld-classic` - they would interpret it as looking for a library `libd_classic`.
 
-The updated SDKs (version 15.1) fixed this issue, so you no longer needed the workround.
+The updated SDKs (version 15.1) fixed this issue, so you no longer needed the workround; but, if you do, see the notes on the [transparent solution](#transparent-solution).
 
 ## <a name="unhandled-exceptions">Unhandled exceptions</a>
 
 It turns out that there's a more subtle problem than the blatant failure to link: exception handling can be unreliable. If you get unhandled exceptions from code with a clearly visible exception handler, this is what's going on.
 
-This issue is also solved by using the classic linker.
+This issue is also solved by using the classic linker: see the notes on the [transparent solution](#transparent-solution). Alternatively, upgrade to a released GCC 14 compiler.
 
-## <a name="transparent-solution">Transparent solution</a>
+### <a name="transparent-solution">Transparent solution</a>
 
 We have a solution which transparently invokes `ld-classic` if it's present in the SDK. The solution is to place a 'shim' named `ld` where GCC will look for it and invoke it instead of directly calling `/usr/bin/ld`.
 
 The latest release of the installer can be found [here](https://github.com/simonjwright/xcode_15_fix/releases).
-
-## <a name="the-future">The future</a>
-
-It turns out that the reason for the issue is that GCC mishandles the Darwin ABI by placing exception handling data in the wrong segment of the executable. This has been fixed in the GCC 14.0.1 pre-release, and it's hoped that it will be backported to GCC 13.3.


### PR DESCRIPTION
In docs/learn/getting-started:
  * installation.md: Updated release verson to 2.0.2. Better link to installation description.
  * macos-issues/alire-vs-aarch64.md: Availability of tools for Apple silicon also mentioned.
  * macos-issues/alire.md: Likewise. Updated stable tools version to 2.0.2.
  * macos-issues/crates.md: Removed links to alr, compilers (now they're all available via alire).
  * macos-issues/issues.md: Reworked. Added discussion of new C, C++ errors related to SDK v16.