### PR TITLE
Update for alr 2.1.0 release & macOS universal build

### DIFF
--- a/docs/learn/getting-started/installation.md
+++ b/docs/learn/getting-started/installation.md
@@ -12,7 +12,7 @@ By far the easiest way to get hold of an Ada toolchain is to use the Ada package
 
 The Alire website's [Releases page](https://github.com/alire-project/alire/releases) provides builds:
 
-- the current stable build, [v2.0.2](https://github.com/alire-project/alire/releases/tag/v2.0.2),
+- the current stable build, [v2.1.0](https://github.com/alire-project/alire/releases/tag/v2.1.0),
 - a [nightly build](https://github.com/alire-project/alire/releases/tag/nightly).
 
 Any of these can be installed as described [here](https://alire.ada.dev/docs/#installation); follow up with these [first steps](https://alire.ada.dev/docs/#first-steps) (this will have the added effect of installing a toolchain for you!)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -61,7 +61,7 @@ export type Target = {
 
 export const installTargets: Map<string, Target> = new Map([
   ["windows", { label: "Windows", urlSuffix: "installer-x86_64-windows.exe" }],
-  ["macos", { label: "macOS", urlSuffix: "bin-aarch64-macos.zip" }],
+  ["macos", { label: "macOS", urlSuffix: "bin-universal-macos.zip" }],
   ["linux", { label: "Linux", urlSuffix: "bin-x86_64-linux.zip" }],
   ["appimage", { label: "AppImage", urlSuffix: "x86_64.AppImage" }]
 ])


### PR DESCRIPTION
I think that the reason that I see the landing page referring to 2.1.0 is that on my machine it's been updated in `.docusaurus/globalData.json`, but I don't see where that update occurred.

  * docs/learn/getting-started/installation.md (Alire): update the stable build to 2.1.0.
  * src/pages/index.tsx (installTargets): for macos, update the urlSuffix from aarch64 to universal.